### PR TITLE
Adding a check for the address.address in on listen event

### DIFF
--- a/lib/fh_cluster.js
+++ b/lib/fh_cluster.js
@@ -46,7 +46,8 @@ function start(workerFunc, numWorkers) {
 
 function setOnWorkerListeningHandler() {
   cluster.on('listening', function(worker, address) {
-    var addr = address.address + ':' + address.port;
+    var host = address.address || address.addressType === 4 ? '0.0.0.0' : '::';
+    var addr = host + ':' + address.port;
     console.log('Cluster worker',  worker.id, 'is now listening at', addr);
   });
 }


### PR DESCRIPTION
Motivation:
When trying out the example given in the README.MD the following is
displayed upon start up:
```shell
Cluster worker 1 is now listening at null:8080
```

The address.address is null when the master receives the listen event.
The port and type of the address are given though.

Modifications:
As a suggestion the check could be added. Another option is to add the
host address specifically to the app.listen(port, hostname) to the
example snippet.

Result:
The logs will now be:
```shell
Cluster worker 1 is now listening at 0.0.0.0:8080
```