### PR TITLE
Add a check for when code/signal are not defined.

### DIFF
--- a/lib/fh_cluster.js
+++ b/lib/fh_cluster.js
@@ -55,7 +55,7 @@ function setupOnExitBackOff(strategy, backoffResetInterval) {
   cluster.on('exit', function(worker, code, signal) {
     var nextRetry = strategy.next();
     setTimeout(function() {
-      var reason = code || signal;
+      var reason = code || signal || 'no code/signal';
       console.log('Worker #', worker.id, 'died with', reason,
                   '. Will retry in', nextRetry, 'ms');
 


### PR DESCRIPTION
Motivation:
When killing a worker using without passing in a signal:
worker.kill();
will lead to the following displayed on stdout:
```shell
Worker # 1 died with null . Will retry in 500 ms
```

Modifications:
Added an addition check if there was neither a code nore signal and in
that case just set the reason to be 'no code/signal'

Result:
When calling worker.kill() the following will be displayed:
```shell
Worker # 1 died with no code/signal . Will retry in 500 ms
```