### PR TITLE
Spawn new worker on disconnect instead of exit

### DIFF
--- a/lib/fh_cluster.js
+++ b/lib/fh_cluster.js
@@ -53,16 +53,17 @@ function setOnWorkerListeningHandler() {
 }
 
 function setupOnExitBackOff(strategy, backoffResetInterval) {
-  cluster.on('exit', function(worker, code, signal) {
-    var nextRetry = strategy.next();
-    setTimeout(function() {
-      var reason = code || signal || 'no code/signal';
-      console.log('Worker #', worker.id, 'died with', reason,
-                  '. Will retry in', nextRetry, 'ms');
+  cluster.on('disconnect', function(worker) {
+    if (cluster.isMaster) {
+      var nextRetry = strategy.next();
+      console.log('Worker #', worker.id, 'disconnected. Will retry in',
+                  nextRetry, 'ms');
 
-      cluster.fork();
-      resetBackoffResetInterval(strategy, backoffResetInterval);
-    }, nextRetry);
+      setTimeout(function() {
+        cluster.fork();
+        resetBackoffResetInterval(strategy, backoffResetInterval);
+      }, nextRetry);
+    }
   });
 }
 

--- a/lib/fh_cluster.js
+++ b/lib/fh_cluster.js
@@ -24,12 +24,12 @@ module.exports = function fhCluster(workerFunc, optionalNumWorkers, optionalBack
     maxDelay: 5000
   });
   var backoffStrategy = _.find([optionalBackoffStrategy, defaultExponentialBackoffStrategy], isValidBackoffStrategy);
-  var backoffResetInterval = resetBackoffResetInterval(backoffStrategy);
+  var backoffResetTimeout = resetBackoffResetTimeout(backoffStrategy);
 
   var numWorkers = _.find([optionalNumWorkers, os.cpus().length], isValidNumWorkers);
 
   setOnWorkerListeningHandler();
-  setupOnExitBackOff(backoffStrategy, backoffResetInterval);
+  setupOnExitBackOff(backoffStrategy, backoffResetTimeout);
 
   start(workerFunc, numWorkers);
 };
@@ -52,7 +52,7 @@ function setOnWorkerListeningHandler() {
   });
 }
 
-function setupOnExitBackOff(strategy, backoffResetInterval) {
+function setupOnExitBackOff(strategy, backoffResetTimeout) {
   cluster.on('disconnect', function(worker) {
     if (cluster.isMaster) {
       var nextRetry = strategy.next();
@@ -61,18 +61,18 @@ function setupOnExitBackOff(strategy, backoffResetInterval) {
 
       setTimeout(function() {
         cluster.fork();
-        resetBackoffResetInterval(strategy, backoffResetInterval);
+        resetBackoffResetTimeout(strategy, backoffResetTimeout);
       }, nextRetry);
     }
   });
 }
 
-function resetBackoffResetInterval(backoffStrategy, interval) {
-  if (interval) {
-    clearInterval(interval);
+function resetBackoffResetTimeout(backoffStrategy, timeout) {
+  if (timeout) {
+    clearTimeout(timeout);
   }
 
-  return setInterval(function() {
+  return setTimeout(function() {
     backoffStrategy.reset();
   }, 60*60*1000);
 }

--- a/test/unit/test_fh_cluster.js
+++ b/test/unit/test_fh_cluster.js
@@ -58,8 +58,8 @@ describe('fh-cluster', function() {
       done();
     });
 
-    it('should have set a handler for cluster exit event', function(done) {
-      sinon.assert.calledWith(cluster.on, sinon.match('exit'));
+    it('should have set a handler for cluster disconnect event', function(done) {
+      sinon.assert.calledWith(cluster.on, sinon.match('disconnect'));
       done();
     });
 


### PR DESCRIPTION
There are some situations where worker.disconnect might be called, but
not worker.kill. The disconnect event will be emitted for both, so it's
better if we re-spawn based on this.

I've also added a condition that the cluster master should do this,
since the disconnect event will get emitted for both the master and
workers.

This change also puts the logging of the backoff message in the correct
place -- the message should appear before the backoff period, rather
than at the end of it.