### PR TITLE
Added Cluster Worker Handoff Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 dist/
 output/
 cov-*
+.idea/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,54 @@ function exampleApp(clusterWorker) {
   app.listen(8081);
 }
 
+//If numWorkers is set to undefined, then the number of CPUs will define the number of Workers.
 var numWorkers = 4;
 fhcluster(exampleApp, numWorkers);
+```
+
+#### Bound Tasks
+
+It is possible to assign tasks to a specific worker. This is useful for the case where only one instance is required (e.g. a scheduler that is intended to work on a single worker only).
+
+Bound Tasks will attempt to bind to the `preferred` worker. If the `preferred` worker exits, the task will be assigned to another worker.
+
+The preference of assigning a task will take into account the number of tasks assigned to other workers. The worker with the lowest number of tasks will be assigned the task.
+
+
+```javascript
+var express = require('express');
+var fhcluster = require('fh-cluster');
+
+function exampleApp(clusterWorker) {
+
+  var app = express();
+  app.get('/', function(req, res) {
+    res.status(200).send('hello from worker #' + clusterWorker.id + '\n');
+  });
+
+  app.listen(8081);
+}
+
+//If numWorkers is set to undefined, then the number of CPUs will define the number of Workers.
+var numWorkers = 4;
+
+//This task should be bound to worker 2.
+var preferredWorkerId = 2;
+
+//A unique ID identifying the task.
+var startEventId = "startMySingleTask";
+
+//This function will be executed to start the task on the preferred worker or another worker if the preferred worker is not available.
+function workerFunction(worker){
+    console.log("Single Bound Task Assigned To Worker " + worker.id);
+};
+
+var singleTask = {
+    workerFunction: workerFunction,
+    preferredWorkerId: preferredWorkerId,
+    startEventId: startEventId
+};
+
+
+fhcluster(exampleApp, numWorkers, [singleTask]);
 ```

--- a/lib/bound_tasks.js
+++ b/lib/bound_tasks.js
@@ -1,0 +1,74 @@
+
+var _ = require('lodash');
+
+function workerIsAlive(worker){
+  return worker.state !== 'dead';
+}
+
+/**
+ * Setting up any bound tasks assigned to a worker.
+ *
+ * This function will check that any bound tasks are assigned to a running worker. If there is no worker assigned
+ */
+function setUpBoundTasks(singleWorkerTasks, cluster){
+
+  //console.log("setUpBoundTasks", singleWorkerTasks, cluster);
+
+  _.each(singleWorkerTasks, function(task){
+    //Does the worker id exist
+
+    //Worker is alive and assigned to the task and still running.
+    if(task.worker && workerIsAlive(task.worker)){
+      return;
+    }
+
+    //If the master does not have any workers, then don't assign them to tasks.
+    if(!cluster.workers){
+      return;
+    }
+
+    //If no worker, assign the preferred worker if available
+    if(!task.worker && cluster.workers[task.preferredWorkerId]){
+      task.worker = cluster.workers[task.preferredWorkerId];
+    } else if(task.worker && !workerIsAlive(task.worker)){
+      //Worker is dead, need to assign it to another worker.
+
+      //Find A Worker With No Task Assigned
+      var workerTasks = _.map(cluster.workers, function(worker){
+        //Check for the worker assigned to tasks
+        var tasks = _.filter(singleWorkerTasks, function(singleWorkerTask){
+          return singleWorkerTask.worker === worker;
+        });
+
+        return {
+          worker: worker,
+          tasks: tasks.length
+        };
+      });
+
+      workerTasks = _.filter(workerTasks, function(workerTask){
+        return workerIsAlive(workerTask.worker);
+      });
+
+      //Find the job with the lowest number of tasks assigned
+      workerTasks = _.sortBy(workerTasks, function(workerTask){
+        return workerTask.tasks;
+      });
+
+      var lowestWorkerTask = _.first(workerTasks);
+
+      task.worker = lowestWorkerTask ? lowestWorkerTask.worker : task.worker;
+    }
+
+    if(task.worker && workerIsAlive(task.worker)){
+      task.worker.send({
+        startEventId: task.startEventId
+      });
+    }
+
+  });
+}
+
+module.exports = {
+  setUpBoundTasks: setUpBoundTasks
+};

--- a/lib/fh_cluster.js
+++ b/lib/fh_cluster.js
@@ -17,16 +17,50 @@ var backoff = require('backoff');
 var cluster = require('cluster');
 var os = require('os');
 var _ = require('lodash');
+var boundTasks = require('./bound_tasks');
+var singleWorkerTasks = [];
+var g_numWorkers;
 
-module.exports = function fhCluster(workerFunc, optionalNumWorkers, optionalBackoffStrategy) {
+
+/**
+ * Function To Start The Cluster Workers And Initialise Any Single Tasks
+ *
+ * @param workerFunc
+ * @param optionalNumWorkers
+ * @param optionalBackoffStrategy
+ * @param boundWorkerTasks: Array Of Worker Tasks To Be Bound To A Specific Process
+ *   - workerFunction: Function To Start The Task
+ *   - startEventId: Event That Will Start The Worker
+ *   - preferredWorkerId: Preferred Worker ID To Bind The Task To
+ */
+module.exports = function fhCluster(workerFunc, optionalNumWorkers, optionalBackoffStrategy, boundWorkerTasks) {
   var defaultExponentialBackoffStrategy = new backoff.ExponentialStrategy({
     initialDelay: 500,
     maxDelay: 5000
   });
+
+  if(_.isArray(optionalNumWorkers)){
+    boundWorkerTasks = optionalNumWorkers;
+    optionalNumWorkers = undefined;
+  } else if(_.isArray(optionalBackoffStrategy)){
+    boundWorkerTasks = optionalBackoffStrategy;
+    optionalBackoffStrategy = undefined;
+  }
+
   var backoffStrategy = _.find([optionalBackoffStrategy, defaultExponentialBackoffStrategy], isValidBackoffStrategy);
   var backoffResetTimeout = resetBackoffResetTimeout(backoffStrategy);
 
   var numWorkers = _.find([optionalNumWorkers, os.cpus().length], isValidNumWorkers);
+  g_numWorkers = numWorkers;
+
+  //Assigning Any Single Worker Tasks
+  singleWorkerTasks = boundWorkerTasks || [];
+
+  var invalidWorkerTask = _.find(singleWorkerTasks, validateSingleWorkerTask);
+
+  if(invalidWorkerTask){
+    throw invalidWorkerTask.error;
+  }
 
   setOnWorkerListeningHandler();
   setupOnExitBackOff(backoffStrategy, backoffResetTimeout);
@@ -34,12 +68,63 @@ module.exports = function fhCluster(workerFunc, optionalNumWorkers, optionalBack
   start(workerFunc, numWorkers);
 };
 
+
+/**
+ * Validating That The Single Worker Task has the required fields
+ * @param task
+ */
+function validateSingleWorkerTask(task){
+
+  var requiredFields = ['workerFunction', 'startEventId', 'preferredWorkerId'];
+
+  var missingFields = _.filter(requiredFields, function(requiredField){
+    return !_.has(task, requiredField);
+  });
+
+  if( _.first(missingFields)){
+    task.error = "Missing Field " + _.first(missingFields);
+    return task;
+  }
+
+  if(!_.isString(task.startEventId) || task.startEventId.length === 0 ){
+    task.error = "Expected startEventId to be a String With Length > 0 ";
+    return task;
+  }
+
+  if(!_.isFunction(task.workerFunction)){
+    task.error = "Expected The workerFunction To Be A Function";
+    return task;
+  }
+
+  if(!_.isNumber(task.preferredWorkerId) || task.preferredWorkerId === 0 || task.preferredWorkerId > g_numWorkers){
+    task.error = "Expected preferredWorkerId to be a number > 0 and < numWorkers";
+    return task;
+  }
+
+  return undefined;
+}
+
 function start(workerFunc, numWorkers) {
+  //Need to store the number of workers
+  g_numWorkers = numWorkers;
   if (cluster.isMaster) {
     _.times(numWorkers, function() {
       cluster.fork();
     });
   } else {
+    cluster.worker.on('message', function(message){
+      if(_.isString(message.startEventId)){
+        //Need to do something
+        var task = _.findWhere(singleWorkerTasks, {startEventId: message.startEventId});
+        if(!task){
+          return;
+        }
+
+        //Execute the required task.
+        task.workerFunction(cluster.worker);
+      }
+    });
+
     workerFunc(cluster.worker);
   }
 }
@@ -49,21 +134,27 @@ function setOnWorkerListeningHandler() {
     var host = address.address || address.addressType === 4 ? '0.0.0.0' : '::';
     var addr = host + ':' + address.port;
     console.log('Cluster worker',  worker.id, 'is now listening at', addr);
+
+    //A new process is listening, need to check if any bound tasks need to be assigned.
+    boundTasks.setUpBoundTasks(singleWorkerTasks, cluster);
+  });
+
+  cluster.on('exit', function(){
+    //If a worker exits, check that all bound workers are on a running worker.
+    boundTasks.setUpBoundTasks(singleWorkerTasks, cluster);
   });
 }
 
 function setupOnExitBackOff(strategy, backoffResetTimeout) {
-  cluster.on('disconnect', function(worker) {
-    if (cluster.isMaster) {
-      var nextRetry = strategy.next();
-      console.log('Worker #', worker.id, 'disconnected. Will retry in',
-                  nextRetry, 'ms');
+  cluster.on('exit', function(worker) {
+    var nextRetry = strategy.next();
+    console.log('Worker #', worker.id, 'exited. Will retry in',
+      nextRetry, 'ms');
 
-      setTimeout(function() {
-        cluster.fork();
-        resetBackoffResetTimeout(strategy, backoffResetTimeout);
-      }, nextRetry);
-    }
+    setTimeout(function() {
+      cluster.fork();
+      resetBackoffResetTimeout(strategy, backoffResetTimeout);
+    }, nextRetry);
   });
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-cluster",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "dependencies": {
     "backoff": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-cluster",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Wraps node cluster module to allow cleaner usage",
   "main": "lib/fh_cluster.js",
   "scripts": {
@@ -17,12 +17,13 @@
     "url": "https://github.com/feedhenry/fh-cluster/issues"
   },
   "devDependencies": {
+    "chai": "^3.4.1",
     "grunt": "^0.4.5",
     "grunt-fh-build": "^0.3.0",
     "istanbul": "^0.3.22",
     "mocha": "^2.3.3",
     "proxyquire": "^1.7.3",
-    "sinon": "^1.17.1"
+    "sinon": "^1.17.2"
   },
   "dependencies": {
     "backoff": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "url": "https://github.com/feedhenry/fh-cluster/issues"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
-    "grunt": "^0.4.5",
-    "grunt-fh-build": "^0.3.0",
-    "istanbul": "^0.3.22",
-    "mocha": "^2.3.3",
-    "proxyquire": "^1.7.3",
-    "sinon": "^1.17.2"
+    "chai": "3.4.1",
+    "grunt": "0.4.5",
+    "grunt-fh-build": "0.3.4",
+    "istanbul": "0.3.22",
+    "mocha": "2.3.3",
+    "proxyquire": "1.7.3",
+    "sinon": "1.17.2"
   },
   "dependencies": {
     "backoff": "2.4.1",

--- a/test/unit/test_bound_tasks.js
+++ b/test/unit/test_bound_tasks.js
@@ -1,0 +1,279 @@
+var sinon = require('sinon');
+var boundTasks = require('../../lib/bound_tasks');
+var assert = require('assert');
+var _ = require('lodash');
+
+
+function createMockTask(preferredWorkerId, startEventId){
+  return {
+    preferredWorkerId: preferredWorkerId,
+    workerFunction: sinon.spy(),
+    startEventId: startEventId
+  };
+}
+
+function createWorkerSendStub(startEventId){
+  var stub = sinon.stub();
+
+  function assignSubValidArgs(startEventId){
+    stub.withArgs(sinon.match({
+        startEventId: startEventId
+      }))
+      .returns(true);
+  }
+
+  if(_.isArray(startEventId)){
+    _.each(startEventId, assignSubValidArgs);
+  } else {
+    assignSubValidArgs(startEventId);
+  }
+
+
+  stub.throws("Invalid Parameters ");
+
+  return stub;
+}
+
+function createMockWorker(id, sendStub, state){
+  return {
+    send: sendStub,
+    id: id,
+    state: state
+  };
+}
+
+describe('Bound Tasks', function() {
+  describe('Single Task', function(){
+    var START_EVENT_ID = "somestartevent1";
+    it('No Workers', function (done) {
+      var mockTask = createMockTask(1, START_EVENT_ID);
+
+      var worker1SendStub = createWorkerSendStub(START_EVENT_ID);
+      var cluster = {
+      };
+
+      var singleBoundTasks = [mockTask];
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      sinon.assert.notCalled(worker1SendStub);
+
+      done();
+    });
+
+    it('Single Task Worker Not Assigned', function (done) {
+      var mockTask = createMockTask(1, START_EVENT_ID);
+
+      var worker1SendStub = createWorkerSendStub(START_EVENT_ID);
+      var mockWorker = createMockWorker(1, worker1SendStub, 'listening');
+
+      var cluster = {
+        workers: {
+          1: mockWorker
+        }
+      };
+
+      var singleBoundTasks = [mockTask];
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      sinon.assert.calledOnce(worker1SendStub);
+      assert.strictEqual(singleBoundTasks[0].worker, mockWorker);
+
+      done();
+    });
+
+    it('Single Task Worker Assigned And Alive', function (done) {
+
+      var mockTask = createMockTask(1, START_EVENT_ID);
+
+      var worker1SendStub = createWorkerSendStub(START_EVENT_ID);
+      var mockWorker = createMockWorker(1, worker1SendStub, 'listening');
+
+      mockTask.worker = mockWorker;
+
+      var cluster = {
+        workers: {
+          1: mockWorker
+        }
+      };
+
+      var singleBoundTasks = [mockTask];
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      //Should not send the message when it is already assigned.
+      sinon.assert.notCalled(worker1SendStub);
+      assert.strictEqual(singleBoundTasks[0].worker, mockWorker);
+
+      done();
+    });
+
+    it('Single Task Worker Assigned And Dead Another Worker Available', function (done) {
+      var mockTask = createMockTask(1, START_EVENT_ID);
+
+      var worker1SendStub = createWorkerSendStub(START_EVENT_ID);
+      var worker2SendStub = createWorkerSendStub(START_EVENT_ID);
+
+      var mockWorker = createMockWorker(1, worker1SendStub, 'dead');
+      var mockWorker2 = createMockWorker(2, worker2SendStub, 'listening');
+
+      //Assigning The Dead Worker. Should Switch To The Alive Worker
+      mockTask.worker = mockWorker;
+
+      var cluster = {
+        workers: {
+          1: mockWorker,
+          2: mockWorker2
+        }
+      };
+
+      var singleBoundTasks = [mockTask];
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      //Should not send the message when it is already assigned.
+      sinon.assert.notCalled(worker1SendStub);
+
+      //Should Send The Message To The Alive Process.
+      sinon.assert.calledOnce(worker2SendStub);
+      //Worker 2 should be assigned to the task/
+      assert.strictEqual(singleBoundTasks[0].worker, mockWorker2);
+
+      done();
+    });
+
+    it('Single Task All Workers Dead', function (done) {
+      var mockTask = createMockTask(1, START_EVENT_ID);
+
+      var worker1SendStub = createWorkerSendStub(START_EVENT_ID);
+      var worker2SendStub = createWorkerSendStub(START_EVENT_ID);
+
+      var mockWorker = createMockWorker(1, worker1SendStub, 'dead');
+      var mockWorker2 = createMockWorker(2, worker2SendStub, 'dead');
+
+      //Assigning The Dead Worker. Should Switch To The Alive Worker
+      mockTask.worker = mockWorker;
+
+      var cluster = {
+        workers: {
+          1: mockWorker,
+          2: mockWorker2
+        }
+      };
+
+      var singleBoundTasks = [mockTask];
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      //Should not send the message when it is already assigned.
+      sinon.assert.notCalled(worker1SendStub);
+
+      //Should Send The Message To The Alive Process.
+      sinon.assert.notCalled(worker2SendStub);
+      //Worker 1 should still be assigned to the task
+      assert.strictEqual(singleBoundTasks[0].worker, mockWorker);
+
+      //Setting Worker 2 To listening
+      mockWorker2.state = 'listening';
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      sinon.assert.calledOnce(worker2SendStub);
+      assert.strictEqual(singleBoundTasks[0].worker, mockWorker2);
+
+      done();
+    });
+  });
+
+  describe('Multiple Tasks', function(){
+    var START_EVENT_ID_1 = "somestartevent1";
+    var START_EVENT_ID_2 = "somestartevent2";
+
+    it('Same Process', function(done){
+      var mockTask = createMockTask(1, START_EVENT_ID_1);
+      var mockTask2 = createMockTask(1, START_EVENT_ID_2);
+
+      var worker1SendStub = createWorkerSendStub([START_EVENT_ID_1, START_EVENT_ID_2]);
+      var mockWorker = createMockWorker(1, worker1SendStub, 'listening');
+
+      var cluster = {
+        workers: {
+          1: mockWorker
+        }
+      };
+
+      var singleBoundTasks = [mockTask, mockTask2];
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      sinon.assert.calledTwice(worker1SendStub);
+
+      assert.strictEqual(singleBoundTasks[0].worker, mockWorker);
+      assert.strictEqual(singleBoundTasks[1].worker, mockWorker);
+
+      done();
+    });
+
+    it('Different Workers', function(done){
+      var mockTask = createMockTask(1, START_EVENT_ID_1);
+      var mockTask2 = createMockTask(2, START_EVENT_ID_2);
+
+      var worker1SendStub = createWorkerSendStub([START_EVENT_ID_1]);
+      var worker2SendStub = createWorkerSendStub([START_EVENT_ID_2]);
+      var mockWorker1 = createMockWorker(1, worker1SendStub, 'listening');
+      var mockWorker2 = createMockWorker(2, worker2SendStub, 'listening');
+
+      var cluster = {
+        workers: {
+          1: mockWorker1,
+          2: mockWorker2
+        }
+      };
+
+      var singleBoundTasks = [mockTask, mockTask2];
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      sinon.assert.calledOnce(worker1SendStub);
+      sinon.assert.calledOnce(worker2SendStub);
+
+      assert.strictEqual(singleBoundTasks[0].worker, mockWorker1);
+      assert.strictEqual(singleBoundTasks[1].worker, mockWorker2);
+
+      done();
+    });
+
+    it('Only Non Working Tasks Should Be Moved', function(done){
+      var mockTask = createMockTask(1, START_EVENT_ID_1);
+      var mockTask2 = createMockTask(2, START_EVENT_ID_2);
+
+      var worker1SendStub = createWorkerSendStub([START_EVENT_ID_2]);
+      var worker2SendStub = createWorkerSendStub([START_EVENT_ID_2]);
+      var mockWorker1 = createMockWorker(1, worker1SendStub, 'listening');
+      var mockWorker2 = createMockWorker(2, worker2SendStub, 'dead');
+
+      mockTask.worker = mockWorker1;
+      mockTask2.worker = mockWorker2;
+
+      var cluster = {
+        workers: {
+          1: mockWorker1,
+          2: mockWorker2
+        }
+      };
+
+      var singleBoundTasks = [mockTask, mockTask2];
+
+      boundTasks.setUpBoundTasks(singleBoundTasks, cluster);
+
+      sinon.assert.notCalled(worker2SendStub);
+      sinon.assert.calledOnce(worker1SendStub);
+
+      assert.strictEqual(singleBoundTasks[0].worker, mockWorker1);
+      assert.strictEqual(singleBoundTasks[1].worker, mockWorker1);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# Bound Tasks

It is possible to assign tasks to a specific worker. This is useful for the case where only one instance is required (e.g. a scheduler that is intended to work on a single worker only).

Bound Tasks will attempt to bind to the `preferred` worker. If the `preferred` worker exits, the task will be assigned to another worker.

The preference of assigning a task will take into account the number of tasks assigned to other workers. The worker with the lowest number of tasks will be assigned the task.


```javascript
var express = require('express');
var fhcluster = require('fh-cluster');

function exampleApp(clusterWorker) {
  var app = express();
  app.get('/', function(req, res) {
    res.status(200).send('hello from worker #' + clusterWorker.id + '\n');
  });

  app.listen(8081);
}

//If numWorkers is set to undefined, then the number of CPUs will define the number of Workers.
var numWorkers = 4;

//This task should be bound to worker 2.
var preferredWorkerId = 2;

//A unique ID identifying the task.
var startEventId = "startMySingleTask";

//This function will be executed to start the task on the preferred worker or another worker if the preferred worker is not available.
function workerFunction(worker){
    console.log("Single Bound Task Assigned To Worker " + worker.id);
};

var singleTask = {
    workerFunction: workerFunction,
    preferredWorkerId: preferredWorkerId,
    startEventId: startEventId
};


fhcluster(exampleApp, numWorkers, [singleTask]);
```